### PR TITLE
Use autoreconf instead of invoking each tool separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,7 @@ For further information see:
 
 To build Adept from a GitHub snapshot, do the following:
 
-    libtoolize
-    aclocal
-    autoheader
-    automake --add-missing
-    autoconf
+    autoreconf -fi
 
 Then the normal make sequence:
 


### PR DESCRIPTION
Note: It might also be a good idea to remove `INSTALL` from the tree since it can be automatically regenerated.